### PR TITLE
Add autopep8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,6 +859,8 @@ Python实现的数据库。
     *   Flake8：模块化源码检查工具: pep8, pyflakes 以及 co。[官网](https://pypi.python.org/pypi/flake8)
     *   Pylint：一个完全可定制的源码分析器。[官网](https://www.pylint.org/)
     *   pylama：Python 和 JavaScript 的代码审查工具。[官网](https://pylama.readthedocs.org/en/latest/)
+*   代码格式化
+    *   autopep8：自动格式化 Python 代码，以使其符合 PEP8 规范。[官网](https://github.com/hhatto/autopep8)
 
 ### Debugging Tools
 


### PR DESCRIPTION
autopep8 是一个命令行下的 python 代码格式化工具, 可以将 Python 代码格式化为符合 PEP8 规范的形式.

由于支持从 stdin 和 stdout 读写, 因此可以和 vim 无缝集成:

``` viml
autocmd FileType python set formatprg=autopep8\ \-
```
