### PR TITLE
新增 poetry 包管理工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Awesome 系列虽然挺全，但基本只对收录的资源做了极为简要的
 *   pip：Python 包和依赖关系管理工具。[官网](https://pip.pypa.io/)
 *   pip-tools：保证 Python 包依赖关系更新的一组工具。[官网](https://github.com/nvie/pip-tools)
 *   pipenv：Pyhton 官方推荐的新一代包管理工具。[官网](https://github.com/pypa/pipenv)
+*   poetry: 可完全取代 setup.py 的包管理工具。[官网](https://poetry.eustace.io)
 *   conda：跨平台，Python 二进制包管理工具。[官网](https://github.com/conda/conda/)
 *   Curdling：管理 Python 包的命令行工具。[官网](http://clarete.li/curdling/)
 *   wheel：Python 分发的新标准，意在取代 eggs。[官网](http://pythonwheels.com/)


### PR DESCRIPTION
### 该 PR 包括

- 新增 poetry 包管理工具 [官网](https://poetry.eustace.io) | [Github](https://github.com/sdispater/poetry)

### 添加理由

用 `poetry` 管理包可以完全替代 `setup.py`，并且一切操作均可在命令行完成：

**添加依赖**：
```
$ poetry add requets
Using version ^2.21 for requests

Updating dependencies
Resolving dependencies... (5.0s)


Package operations: 5 installs, 0 updates, 0 removals

Writing lock file

  - Installing certifi (2018.11.29)
  - Installing chardet (3.0.4)
  - Installing idna (2.8)
  - Installing urllib3 (1.24.1)
  - Installing requests (2.21.0)
```
**添加开发环境依赖**：
```
$ poetry add -D pytest=^4.0
Using version ^4.0 for pytest

Updating dependencies
Resolving dependencies... (2.2s)


Package operations: 0 installs, 1 update, 0 removals

Writing lock file

  - Updating six (1.11.0 -> 1.12.0)
```
**安装所有依赖**：
```
$ poetry install
```
**用树状图显示当前项目所有依赖**：
```
$ poetry show --tree
pytest 4.0.1 pytest: simple powerful testing with Python
├── atomicwrites >=1.0
├── attrs >=17.4.0
├── colorama *
├── more-itertools >=4.0.0
│   └── six >=1.0.0,<2.0.0
├── pluggy >=0.7
├── py >=1.5.0
├── setuptools *
└── six >=1.10.0
requests 2.21.0 Python HTTP for Humans.
├── certifi >=2017.4.17
├── chardet >=3.0.2,<3.1.0
├── idna >=2.5,<2.9
└── urllib3 >=1.21.1,<1.25
```
**一键打包**：
```
$ poetry build
```
**一键发布到 [PyPI](https://pypi.org)**：
```
$ poetry publish
```

